### PR TITLE
Update 42_Type_String.md

### DIFF
--- a/docs/Pyllole/42_Type_String.md
+++ b/docs/Pyllole/42_Type_String.md
@@ -100,7 +100,7 @@ Con le _f-string_ è possibile anche eseguire delle espressioni all'interno del 
 >>> seven = 7
 >>> f'''Il suo nome è {name.upper()}
 ...ed ha {6 * seven} anni.'''
-'Il suo nome è John ed ha 42 anni.'
+'Il suo nome è JOHN ed ha 42 anni.'
 ```
 
 


### PR DESCRIPTION
make John Upper

## Why

Buongiorno,
Vi scrivo per comunicarvi che abbiamo individuato un errore nella sezione "Tipi: Stringhe" sul vostro sito Python ABC, nel codice sotto riportato.
Dal codice scritto, si dovrebbe avere un output con il name "John" tutto maiuscolo, ma ciò non avviene.
Ringrazio per la cortese attenzione,
Matteo Ferriolo e Mattia Liam Barelli
