### PR TITLE
Remove ForumPython (domain expired)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,6 @@ Prima di voler scrivere un qualunque programma con Python è necessario conoscer
 ## Principali Riferimenti Online
 * **Python.org**: [il sito ufficiale in inglese](https://docs.python.org)
 * **Python.it** : [sito ufficiale italiano](http://www.python.it/) - [Forum](http://www.python.it/forum) - [Telegram](https://t.me/python_ita) - [Mailing list](http://www.python.it/comunita/mailing-list/)
-* **Forumpython.it**: [Sito e Forum](http://forumpython.it)
 
 **Nello studio e nelle ricerche fai sempre riferimento a Python 3.x**, Python 2 non è più supportato dal  1° gennaio 2020, maggiori informazioni [qui](https://www.python.org/doc/sunset-python-2/).
 


### PR DESCRIPTION
## Why

As of today, the website appears to be offline and a domain parking page is displayed instead.

## How to test it

Current state:

- Go to https://pythonitalia.github.io/python-abc/
- Look for "Forumpython.it" under the "Principali Riferimenti Online" header
- Click on link "Sito e Forum"
- The displayed page is domain parking advertisement

New state:

- Build project locally
- Open project home page (`index.md`)
- Verify that (only) "Forumpython.it" was removed from the "Principali Riferimenti Online" section